### PR TITLE
Downgraded to .NET Standard 1.3 replacing nodejs by Jint javascript engine

### DIFF
--- a/CloudflareSolver.Sandbox/CloudflareSolver.Sandbox.csproj
+++ b/CloudflareSolver.Sandbox/CloudflareSolver.Sandbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Cloudflare.Sandbox</RootNamespace>
   </PropertyGroup>
 

--- a/CloudflareSolver/CloudflareSolver.csproj
+++ b/CloudflareSolver/CloudflareSolver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <RootNamespace>Cloudflare</RootNamespace>
     <PackageIconUrl>https://i.imgur.com/1kOksXx.png</PackageIconUrl>
     <Version>1.1.1</Version>
@@ -23,7 +23,9 @@
 
   <ItemGroup>
     <PackageReference Include="2CaptchaAPI" Version="1.3.1" />
+    <PackageReference Include="Jint" Version="2.11.58" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I think requiring nodejs to be installed doesn't suit a .NET library.
Also [ProcessStartInfo](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo?view=netframework-4.7.2#applies-to) requires .NET Standard 2.0
So, [Jint](https://github.com/sebastienros/jint) library only needs .NET Standard 1.3

I hope you accept this :)
